### PR TITLE
Bump to v0.10.0

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": false
+}

--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -27,7 +27,11 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
     sources:
-      - type: git
-        url: https://github.com/flameshot-org/flameshot.git
-        tag: "v0.9.0"
-        commit: "5690afbd4be857e20e0ff6f100c890a7250cccfe"
+      - type: archive
+        url: https://github.com/flameshot-org/flameshot/archive/v0.9.0.tar.gz
+        sha256: 67e0b578ef8a68228e758cb59395bb7404b5c176e9dbc3ca2d83a63f154a6f22
+        x-checker-data:
+          type: anitya
+          project-id: 16948
+          stable-only: true
+          url-template: https://github.com/flameshot-org/flameshot/archive/v$version.tar.gz

--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -26,12 +26,18 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+    post-install:
+      - desktop-file-edit --set-key=Exec --set-value=flameshot ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
     sources:
       - type: archive
-        url: https://github.com/flameshot-org/flameshot/archive/v0.9.0.tar.gz
-        sha256: 67e0b578ef8a68228e758cb59395bb7404b5c176e9dbc3ca2d83a63f154a6f22
+        url: https://github.com/flameshot-org/flameshot/archive/v0.10.0.tar.gz
+        sha256: 44e53c5dcefddb05bd6fa1af667df287f44baa1746468bfab5f76318c0bb3f83
         x-checker-data:
           type: anitya
           project-id: 16948
           stable-only: true
           url-template: https://github.com/flameshot-org/flameshot/archive/v$version.tar.gz
+    cleanup:
+      - /share/bash-completion
+      - /share/man
+      - /share/zsh


### PR DESCRIPTION
## Add flatpak-external-data-checker support

* Add x-checker-data property for f-e-d-c.
* Anitya checker was chosen as currently the git checker doesn't support timestamp, so flathubbot will open a new PR on every run if the previous one wasn't merged.  
We could stay on git source type and use the JSON checker, but Github has a 60 API requests hourly limit for unauthenticated requests, so it's not fun to work with locally.

## Update to v0.10.0
* First time updating (manually) with f-e-d-c, next update PRs will be opened automatically by flathubbot.
* I chose not to have flathubbot auto-merge PRs with a successful CI build run.
* I had to edit the `Exec` entry in the desktop file, as it's hardcoding `/usr/bin` path.  **edit: this need to be fixed upstream**  
It seems to work correctly with `desktop-file-edit` even though the desktop file has multiple groups, it only changes the key value in the `Desktop Entry` group.
* A cleanup property was added to remove unneeded man page and shell completions, as this is the convention

Build was only tested with Sway 1.6.1.