### PR TITLE
Remove desktop file Exec entry workaround

### DIFF
--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -26,8 +26,6 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-    post-install:
-      - desktop-file-edit --set-key=Exec --set-value=flameshot ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
     sources:
       - type: archive
         url: https://github.com/flameshot-org/flameshot/archive/v11.0.0.tar.gz


### PR DESCRIPTION
The hardcoded executable /usr/bin path issue was fixed in flameshot-org/flameshot@1031980ed1e62d24d7f719998b7951d48801e3fa.
With v11.0.0 release we get the correct value /app/bin/flameshot.