### PR TITLE
CI: Switch to JSON f-e-d-c checker

### DIFF
--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -28,13 +28,15 @@ modules:
       - -DCMAKE_BUILD_TYPE=Release
     sources:
       - type: archive
-        url: https://github.com/flameshot-org/flameshot/archive/v12.1.0.tar.gz
+        url: https://github.com/flameshot-org/flameshot/archive/v12.1.0/flameshot-12.1.0.tar.gz
         sha256: c82c05d554e7a6d810aca8417ca12b21e4f74864455ab4ac94602668f85ac22a
         x-checker-data:
-          type: anitya
-          project-id: 16948
-          stable-only: true
-          url-template: https://github.com/flameshot-org/flameshot/archive/v$version.tar.gz
+          is-main-source: true
+          type: json
+          url: https://api.github.com/repos/flameshot-org/flameshot/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: '"https://github.com/flameshot-org/flameshot/archive/v" + $version
+            + "/flameshot-" + $version + ".tar.gz"'
     cleanup:
       - /share/bash-completion
       - /share/man


### PR DESCRIPTION
JSON checker will get us more prompt update PRs, as
release-monitoring.org is a bit slow detecting new releases.
Also set is-main-source property, though there are no benefits atm, as
there's only one module in the manifest.