### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -20,7 +20,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   # System Tray Icon
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
 modules:
   - name: flameshot
     buildsystem: cmake-ninja


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025

Check after runtime is updated to 22.08 https://github.com/flathub/org.flameshot.Flameshot/pull/19