### PR TITLE
Allow access to xdg-pictures

### DIFF
--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -14,6 +14,8 @@ finish-args:
   - --share=network
   # QtSingleApplication, allow other instances to see log files
   - --env=TMPDIR=/var/tmp
+  # Allow setting xdg-pictures as save directory permanently
+  - --filesystem=xdg-pictures
   # Notification access
   - --talk-name=org.freedesktop.Notifications
   # System Tray Icon


### PR DESCRIPTION
336226bf506a9b0cc3282cbc662d96993a08d31f revoked host access because it was too broad. The app needs access to one directory to make it the permanent save location. Since that "choosing" goes through the portal-ed filechooser, a mounted path from the portal is returned which is lost on restarts without filesystem access.

So allow access to the most common location to save screenshots