### PR TITLE
Update to KDE runtime 5.15-24.08

### DIFF
--- a/flameshot.appdata.patch
+++ b/flameshot.appdata.patch
@@ -1,0 +1,14 @@
+diff --git i/data/appdata/org.flameshot.Flameshot.metainfo.xml w/data/appdata/org.flameshot.Flameshot.metainfo.xml
+index a4242951..8a948c3c 100644
+--- i/data/appdata/org.flameshot.Flameshot.metainfo.xml
++++ w/data/appdata/org.flameshot.Flameshot.metainfo.xml
+@@ -8,6 +8,9 @@ SPDX-License-Identifier: CC0-1.0
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-3.0-or-later</project_license>
+   <name>Flameshot</name>
++  <developer id="org.flameshot">
++    <name>Flameshot Developers</name>
++  </developer>
+   <releases>
+     <release version="12.1.0" date="2022-07-03"/>
+     <release version="12.0.0" date="2022-06-21"/>

--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -34,6 +34,8 @@ modules:
           project-id: 16948
           stable-only: true
           url-template: https://github.com/flameshot-org/flameshot/archive/v$version.tar.gz
+      - type: patch
+        path: flameshot.appdata.patch
     cleanup:
       - /share/bash-completion
       - /share/man

--- a/org.flameshot.Flameshot.yml
+++ b/org.flameshot.Flameshot.yml
@@ -1,6 +1,6 @@
 app-id: org.flameshot.Flameshot
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: 5.15-24.08
 sdk: org.kde.Sdk
 command: flameshot
 finish-args:


### PR DESCRIPTION
Commit updates KDE runtime to `5.15-24.08` and resolves usage of
unsupported and outdated version manifested by output like below:

```
$ flatpak update

Looking for updates…

Info: (pinned) runtime org.kde.Platform branch 5.15-23.08 is
end-of-life, with reason:
   We strongly recommend moving to the latest Qt 5.15-based stable
version of the Platform and SDK
Info: applications using this runtime:
   org.flameshot.Flameshot
```

Fixes https://github.com/flathub/org.flameshot.Flameshot/issues/26.
